### PR TITLE
Automatically set OffsetX/OffsetY to position the RoI in the centre of the sensor

### DIFF
--- a/src/gstvimbasrc.c
+++ b/src/gstvimbasrc.c
@@ -1561,6 +1561,8 @@ VmbError_t set_roi(GstVimbaSrc *vimbasrc)
     // offsetx
     if (vimbasrc->properties.offsetx == -1) {
         VmbInt64_t vmb_offsetx = (vmb_width - vimbasrc->properties.width) >> 1;
+        GST_DEBUG_OBJECT(vimbasrc, "ROI centering along x-axis requested. Calculated offsetx=%d",
+                         vmb_offsetx);
         g_object_set(vimbasrc, "offsetx", (int) vmb_offsetx, NULL);
     }
     GST_DEBUG_OBJECT(vimbasrc, "Setting \"OffsetX\" to %d", vimbasrc->properties.offsetx);
@@ -1580,6 +1582,8 @@ VmbError_t set_roi(GstVimbaSrc *vimbasrc)
     // offsety
     if (vimbasrc->properties.offsety == -1) {
         VmbInt64_t vmb_offsety = (vmb_height - vimbasrc->properties.height) >> 1;
+        GST_DEBUG_OBJECT(vimbasrc, "ROI centering along y-axis requested. Calculated offsety=%d",
+                         vmb_offsety);
         g_object_set(vimbasrc, "offsety", (int)vmb_offsety, NULL);
     }
     GST_DEBUG_OBJECT(vimbasrc, "Setting \"OffsetY\" to %d", vimbasrc->properties.offsety);

--- a/src/gstvimbasrc.c
+++ b/src/gstvimbasrc.c
@@ -1580,8 +1580,6 @@ VmbError_t set_roi(GstVimbaSrc *vimbasrc)
     // offsety
     if (vimbasrc->properties.offsety == INT_MAX) {
         VmbInt64_t vmb_offsety = (vmb_height - vimbasrc->properties.height) >> 1;
-        GST_DEBUG_OBJECT(vimbasrc, "Setting \"OffsetX\" to %d", vmb_offsety);
-        result = VmbFeatureIntSet(vimbasrc->camera.handle, "OffsetY", vmb_offsety);
         g_object_set(vimbasrc, "offsety", (int)vmb_offsety, NULL);
     }
     GST_DEBUG_OBJECT(vimbasrc, "Setting \"OffsetY\" to %d", vimbasrc->properties.offsety);

--- a/src/gstvimbasrc.c
+++ b/src/gstvimbasrc.c
@@ -377,10 +377,10 @@ static void gst_vimbasrc_class_init(GstVimbaSrcClass *klass)
         g_param_spec_int(
             "offsetx",
             "OffsetX feature setting",
-            "Horizontal offset from the origin to the region of interest (in pixels).",
+            "Horizontal offset from the origin to the region of interest (in pixels). If no explicit value is passed the RoI will be centered in the sensor.",
             0,
             G_MAXINT,
-            0,
+            G_MAXINT,
             G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
     g_object_class_install_property(
         gobject_class,
@@ -388,10 +388,10 @@ static void gst_vimbasrc_class_init(GstVimbaSrcClass *klass)
         g_param_spec_int(
             "offsety",
             "OffsetY feature setting",
-            "Vertical offset from the origin to the region of interest (in pixels).",
+            "Vertical offset from the origin to the region of interest (in pixels). If no explicit value is passed the RoI will be centered in the sensor.",
             0,
             G_MAXINT,
-            0,
+            G_MAXINT,
             G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
     g_object_class_install_property(
         gobject_class,
@@ -1508,11 +1508,12 @@ VmbError_t set_roi(GstVimbaSrc *vimbasrc)
                            ErrorCodeToMessage(result));
     }
 
+    VmbInt64_t vmb_width;
+    result = VmbFeatureIntRangeQuery(vimbasrc->camera.handle, "Width", NULL, &vmb_width);
+
     // Set Width to full sensor if no explicit width was set
     if (vimbasrc->properties.width == INT_MAX)
     {
-        VmbInt64_t vmb_width;
-        result = VmbFeatureIntRangeQuery(vimbasrc->camera.handle, "Width", NULL, &vmb_width);
         GST_DEBUG_OBJECT(vimbasrc,
                          "Setting \"Width\" to full width. Got sensor width \"%lld\" (Return Code %s)",
                          vmb_width,
@@ -1533,11 +1534,11 @@ VmbError_t set_roi(GstVimbaSrc *vimbasrc)
                            ErrorCodeToMessage(result));
     }
 
+    VmbInt64_t vmb_height;
+    result = VmbFeatureIntRangeQuery(vimbasrc->camera.handle, "Height", NULL, &vmb_height);
     // Set Height to full sensor if no explicit height was set
     if (vimbasrc->properties.height == INT_MAX)
     {
-        VmbInt64_t vmb_height;
-        result = VmbFeatureIntRangeQuery(vimbasrc->camera.handle, "Height", NULL, &vmb_height);
         GST_DEBUG_OBJECT(vimbasrc,
                          "Setting \"Height\" to full height. Got sensor height \"%lld\" (Return Code %s)",
                          vmb_height,
@@ -1558,6 +1559,10 @@ VmbError_t set_roi(GstVimbaSrc *vimbasrc)
                            ErrorCodeToMessage(result));
     }
     // offsetx
+    if (vimbasrc->properties.offsetx == INT_MAX) {
+        VmbInt64_t vmb_offsetx = (vmb_width - vimbasrc->properties.width) >> 1;
+        g_object_set(vimbasrc, "offsetx", (int) vmb_offsetx, NULL);
+    }
     GST_DEBUG_OBJECT(vimbasrc, "Setting \"OffsetX\" to %d", vimbasrc->properties.offsetx);
     result = VmbFeatureIntSet(vimbasrc->camera.handle, "OffsetX", vimbasrc->properties.offsetx);
     if (result == VmbErrorSuccess)
@@ -1573,6 +1578,12 @@ VmbError_t set_roi(GstVimbaSrc *vimbasrc)
     }
 
     // offsety
+    if (vimbasrc->properties.offsety == INT_MAX) {
+        VmbInt64_t vmb_offsety = (vmb_height - vimbasrc->properties.height) >> 1;
+        GST_DEBUG_OBJECT(vimbasrc, "Setting \"OffsetX\" to %d", vmb_offsety);
+        result = VmbFeatureIntSet(vimbasrc->camera.handle, "OffsetY", vmb_offsety);
+        g_object_set(vimbasrc, "offsety", (int)vmb_offsety, NULL);
+    }
     GST_DEBUG_OBJECT(vimbasrc, "Setting \"OffsetY\" to %d", vimbasrc->properties.offsety);
     result = VmbFeatureIntSet(vimbasrc->camera.handle, "OffsetY", vimbasrc->properties.offsety);
     if (result == VmbErrorSuccess)

--- a/src/gstvimbasrc.c
+++ b/src/gstvimbasrc.c
@@ -377,10 +377,10 @@ static void gst_vimbasrc_class_init(GstVimbaSrcClass *klass)
         g_param_spec_int(
             "offsetx",
             "OffsetX feature setting",
-            "Horizontal offset from the origin to the region of interest (in pixels). If no explicit value is passed the RoI will be centered in the sensor.",
+            "Horizontal offset from the origin to the region of interest (in pixels). If -1 is passed the ROI will be centered in the sensor along the horizontal axis.",
+            -1,
+            G_MAXINT,
             0,
-            G_MAXINT,
-            G_MAXINT,
             G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
     g_object_class_install_property(
         gobject_class,
@@ -388,10 +388,10 @@ static void gst_vimbasrc_class_init(GstVimbaSrcClass *klass)
         g_param_spec_int(
             "offsety",
             "OffsetY feature setting",
-            "Vertical offset from the origin to the region of interest (in pixels). If no explicit value is passed the RoI will be centered in the sensor.",
+            "Vertical offset from the origin to the region of interest (in pixels). If -1 is passed the ROI will be centered in the sensor along the vertical axis.",
+            -1,
+            G_MAXINT,
             0,
-            G_MAXINT,
-            G_MAXINT,
             G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
     g_object_class_install_property(
         gobject_class,
@@ -1559,7 +1559,7 @@ VmbError_t set_roi(GstVimbaSrc *vimbasrc)
                            ErrorCodeToMessage(result));
     }
     // offsetx
-    if (vimbasrc->properties.offsetx == INT_MAX) {
+    if (vimbasrc->properties.offsetx == -1) {
         VmbInt64_t vmb_offsetx = (vmb_width - vimbasrc->properties.width) >> 1;
         g_object_set(vimbasrc, "offsetx", (int) vmb_offsetx, NULL);
     }
@@ -1578,7 +1578,7 @@ VmbError_t set_roi(GstVimbaSrc *vimbasrc)
     }
 
     // offsety
-    if (vimbasrc->properties.offsety == INT_MAX) {
+    if (vimbasrc->properties.offsety == -1) {
         VmbInt64_t vmb_offsety = (vmb_height - vimbasrc->properties.height) >> 1;
         g_object_set(vimbasrc, "offsety", (int)vmb_offsety, NULL);
     }


### PR DESCRIPTION
When a width/height less than the maximum sensor size is specified, it's not automatically centred in the sensor but placed at offset 0,0. This means that the centre of the returned images do not correspond with the optical sensor of the lens/camera.   
In order to centre it, it would be necessary to obtain the sensor width and height which the plugin does not expose as parameters. Instead, the existing approach used for width/height is copied, and a value of INT_MAX is interpreted as 'centre the RoI within the sensor for this axis'.
I have made the assumption that, like width/height, this behaviour should be the default.