### PR TITLE
Add GstDeviceProvider for Vimba devices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 add_library(${PROJECT_NAME} SHARED
     src/gstvimbasrc.c
     src/gstvimbasrc_device.c
+    src/gstvimbasrc_deviceprovider.c
     src/vimba_helpers.c
     src/pixelformats.c
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
 add_library(${PROJECT_NAME} SHARED
     src/gstvimbasrc.c
+    src/gstvimbasrc_device.c
     src/vimba_helpers.c
     src/pixelformats.c
 )

--- a/src/gstvimbasrc.c
+++ b/src/gstvimbasrc.c
@@ -30,6 +30,7 @@
  */
 
 #include "gstvimbasrc.h"
+#include "gstvimbasrc_deviceprovider.h"
 #include "helpers.h"
 #include "vimba_helpers.h"
 #include "pixelformats.h"
@@ -1288,8 +1289,15 @@ static gboolean plugin_init(GstPlugin *plugin)
                             "debug category for vimbasrc element");
 
     /* FIXME Remember to set the rank if it's an element that is meant to be autoplugged by decodebin. */
-    return gst_element_register(plugin, "vimbasrc", GST_RANK_NONE,
-                                GST_TYPE_vimbasrc);
+    if (!gst_element_register(plugin, "vimbasrc", GST_RANK_NONE, GST_TYPE_vimbasrc))
+    {
+        return FALSE;
+    }
+
+    return gst_device_provider_register(plugin,
+                                        "vimbasrcdeviceprovider",
+                                        GST_RANK_PRIMARY + 1,
+                                        GST_TYPE_VIMBASRC_DEVICE_PROVIDER);
 }
 
 GST_PLUGIN_DEFINE(GST_VERSION_MAJOR,

--- a/src/gstvimbasrc.h
+++ b/src/gstvimbasrc.h
@@ -37,6 +37,9 @@ G_BEGIN_DECLS
 #define GST_IS_vimbasrc(obj) (G_TYPE_CHECK_INSTANCE_TYPE((obj), GST_TYPE_vimbasrc))
 #define GST_IS_vimbasrc_CLASS(obj) (G_TYPE_CHECK_CLASS_TYPE((klass), GST_TYPE_vimbasrc))
 
+GST_DEBUG_CATEGORY_EXTERN (gst_vimbasrc_debug_category);
+#define GST_CAT_DEFAULT gst_vimbasrc_debug_category
+
 /* Allowed values for "Auto" camera Features */
 typedef enum
 {
@@ -201,5 +204,22 @@ VmbError_t stop_image_acquisition(GstVimbaSrc *vimbasrc);
 void VMB_CALL vimba_frame_callback(const VmbHandle_t cameraHandle, VmbFrame_t *pFrame);
 void map_supported_pixel_formats(GstVimbaSrc *vimbasrc);
 void log_available_enum_entries(GstVimbaSrc *vimbasrc, const char *feat_name);
+
+/**
+ * @brief Start the global Vimba instance if needed
+ * 
+ * @param vimbasrc GStreamer object which requested the vimba instance
+ */
+void start_vimba(GstObject *vimbasrc);
+
+/**
+ * @brief Stop the global vimba instance
+ * 
+ * Only stops it if the reference count is zero,
+ * otherwise only the reference count is decreased.
+ * 
+ * @param vimbasrc GStreamer object which requested the vimba instance
+ */
+void stop_vimba(GstObject *vimbasrc);
 
 #endif

--- a/src/gstvimbasrc_device.c
+++ b/src/gstvimbasrc_device.c
@@ -1,0 +1,229 @@
+/*
+ * Copyright (C) 2023 Allied Vision Technologies GmbH
+ * Copyright (C) 2023 Fraunhofer Institute for Material and Beam Technology IWS
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License version 2.0 as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "gstvimbasrc_device.h"
+#include "gstvimbasrc.h"
+
+#include <gst/gst.h>
+
+G_DEFINE_TYPE(GstVimbaSrcDevice, gst_vimbasrc_device, GST_TYPE_DEVICE)
+
+enum
+{
+  PROP_CAMERA_ID = 1,
+  PROP_CAMERA_MODEL,
+  PROP_CAMERA_NAME,
+  PROP_SERIAL,
+  PROP_INTERFACE_ID
+};
+
+/**
+ * @brief Called by GStreamer to create the source element matching the device
+ *
+ * @param device The device for which to create the source element
+ * @param name Unique name of the new element (or NULL for automatic assignment)
+ * @return GstElement* vimbasrc element
+ */
+static GstElement *
+gst_vimbasrc_device_create_element(GstDevice *device, const gchar *name)
+{
+  GstVimbaSrcDevice *vimba_device = GST_VIMBASRC_DEVICE(device);
+  GstElement *element = gst_element_factory_make(vimba_device->element, name);
+
+  g_object_set (element, "camera", vimba_device->camera_id, NULL);
+
+  return element;
+}
+
+/**
+ * @brief Reconfigure a vimbasrc element to use this camera device
+ *
+ * @param device Device which the vimbasrc should use
+ * @param element vimbasrc element to reconfigure
+ * @return gboolean
+ */
+static gboolean
+gst_vimbasrc_device_reconfigure_element(GstDevice *device, GstElement *element)
+{
+  GstVimbaSrcDevice *vimba_device = GST_VIMBASRC_DEVICE(device);
+  if (!GST_IS_vimbasrc(element))
+  {
+      return FALSE;
+  }
+
+  g_object_set (element, "camera", vimba_device->camera_id, NULL);
+  return TRUE;
+}
+
+/**
+ * @brief GStreamer function called when getting a g_object property
+ *
+ * @param object The vimbasrc device
+ * @param property_id The id of the property to get
+ * @param value Output value pointer
+ * @param pspec
+ */
+static void
+gst_vimbasrc_device_get_property(GObject *object, guint property_id, GValue *value, GParamSpec *pspec)
+{
+  GstVimbaSrcDevice *device = GST_VIMBASRC_DEVICE_CAST(object);
+
+  switch (property_id) {
+    case PROP_CAMERA_ID:
+      g_value_set_string(value, device->camera_id);
+      break;
+    case PROP_CAMERA_NAME:
+      g_value_set_string(value, device->camera_name);
+      break;
+    case PROP_CAMERA_MODEL:
+      g_value_set_string(value, device->camera_model);
+      break;
+    case PROP_SERIAL:
+      g_value_set_string(value, device->serial);
+      break;
+    case PROP_INTERFACE_ID:
+      g_value_set_string(value, device->interface_id);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+      break;
+  }
+}
+
+/**
+ * @brief GStreamer function called when setting a property (GObject)
+ *
+ * @param object The vimbasrc device
+ * @param property_id Id of the property to set
+ * @param value Value to assign to the property
+ * @param pspec
+ */
+static void
+gst_vimbasrc_device_set_property(GObject *object, guint property_id, const GValue *value, GParamSpec *pspec)
+{
+  GstVimbaSrcDevice *device = GST_VIMBASRC_DEVICE_CAST(object);
+
+  switch (property_id) {
+    case PROP_CAMERA_ID:
+      g_free(device->camera_id);
+      device->camera_id = g_value_dup_string(value);
+      break;
+    case PROP_CAMERA_NAME:
+      g_free(device->camera_name);
+      device->camera_name = g_value_dup_string(value);
+      break;
+    case PROP_CAMERA_MODEL:
+     g_free(device->camera_model);
+      device->camera_model = g_value_dup_string(value);
+      break;
+    case PROP_SERIAL:
+      g_free(device->serial);
+      device->serial = g_value_dup_string(value);
+      break;
+    case PROP_INTERFACE_ID:
+      g_free(device->interface_id);
+      device->interface_id = g_value_dup_string(value);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
+      break;
+  }
+}
+
+/**
+ * @brief GLib function called to free a VimbaSrcDevice
+ *
+ * @param object VimbaSrcDevice to free
+ */
+static void
+gst_vimbasrc_device_finalize (GObject *object)
+{
+  GstVimbaSrcDevice *device = GST_VIMBASRC_DEVICE_CAST(object);
+  g_free(device->camera_id);
+  g_free(device->camera_name);
+  g_free(device->camera_model);
+  g_free(device->serial);
+  g_free(device->interface_id);
+
+  G_OBJECT_CLASS (gst_vimbasrc_device_parent_class)->finalize(object);
+}
+
+/**
+ * @brief GLib function called to initialize the VimbaSrcDevice class struct
+ *
+ * The place to install all properties.
+ *
+ * @param klass
+ */
+static void
+gst_vimbasrc_device_class_init (GstVimbaSrcDeviceClass * klass)
+{
+  GstDeviceClass *dev_class = GST_DEVICE_CLASS(klass);
+  GObjectClass *object_class = G_OBJECT_CLASS(klass);
+
+  dev_class->create_element = gst_vimbasrc_device_create_element;
+  dev_class->reconfigure_element = gst_vimbasrc_device_reconfigure_element;
+
+  object_class->get_property = gst_vimbasrc_device_get_property;
+  object_class->set_property = gst_vimbasrc_device_set_property;
+  object_class->finalize = gst_vimbasrc_device_finalize;
+
+  g_object_class_install_property(object_class, PROP_CAMERA_ID,
+      g_param_spec_string("camera-id",
+                          "Camera Id",
+                          "Unique identifier for each camera",
+                          NULL,
+                          (G_PARAM_STATIC_STRINGS | G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY)));
+  g_object_class_install_property(object_class, PROP_CAMERA_NAME,
+      g_param_spec_string("camera-name",
+                          "Camera Name",
+                          "Name of the camera",
+                          NULL,
+                          (G_PARAM_STATIC_STRINGS | G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY)));
+  g_object_class_install_property(object_class, PROP_CAMERA_MODEL,
+      g_param_spec_string("camera-model",
+                          "Camera Model Id",
+                          "The camera model name",
+                          NULL,
+                          (G_PARAM_STATIC_STRINGS | G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY)));
+  g_object_class_install_property(object_class, PROP_SERIAL,
+      g_param_spec_string("serial",
+                          "Camera Serial String",
+                          "The serial number of the camera",
+                          NULL,
+                          (G_PARAM_STATIC_STRINGS | G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY)));
+  g_object_class_install_property(object_class, PROP_INTERFACE_ID,
+      g_param_spec_string("interface-id",
+                          "Interface Id String",
+                          "Unique value for each interface or bus",
+                          NULL,
+                          (G_PARAM_STATIC_STRINGS | G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY)));
+}
+
+/**
+ * @brief GLib function called to initialize a VimbaSrcDevice instance
+ *
+ * @param device
+ */
+static void
+gst_vimbasrc_device_init (GstVimbaSrcDevice *device)
+{
+  GST_TRACE_OBJECT(device, "gst-vimbasrc-device init");
+  device->element = "vimbasrc";
+}

--- a/src/gstvimbasrc_device.h
+++ b/src/gstvimbasrc_device.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2023 Allied Vision Technologies GmbH
+ * Copyright (C) 2023 Fraunhofer Institute for Material and Beam Technology IWS
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License version 2.0 as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef _GST_VIMBASRC_DEVICE_H_
+#define _GST_VIMBASRC_DEVICE_H_
+
+#include <glib.h>
+#include <gst/base/base.h>
+
+G_BEGIN_DECLS
+
+/* The GstDevice */
+
+typedef struct _GstVimbaSrcDevice GstVimbaSrcDevice;
+typedef struct _GstVimbaSrcDeviceClass GstVimbaSrcDeviceClass;
+
+#define GST_TYPE_VIMBASRC_DEVICE                 (gst_vimbasrc_device_get_type())
+#define GST_IS_VIMBASRC_DEVICE(obj)              (G_TYPE_CHECK_INSTANCE_TYPE ((obj), GST_TYPE_VIMBASRC_DEVICE))
+#define GST_IS_VIMBASRC_DEVICE_CLASS(klass)      (G_TYPE_CHECK_CLASS_TYPE ((klass), GST_TYPE_VIMBASRC_DEVICE))
+#define GST_VIMBASRC_DEVICE_GET_CLASS(obj)       (G_TYPE_INSTANCE_GET_CLASS ((obj), GST_TYPE_VIMBASRC_DEVICE, GstVimbaSrcDeviceClass))
+#define GST_VIMBASRC_DEVICE(obj)                 (G_TYPE_CHECK_INSTANCE_CAST ((obj), GST_TYPE_VIMBASRC_DEVICE, GstVimbaSrcDevice))
+#define GST_VIMBASRC_DEVICE_CLASS(klass)         (G_TYPE_CHECK_CLASS_CAST ((klass), GST_TYPE_DEVICE, GstVimbaSrcDeviceClass))
+#define GST_VIMBASRC_DEVICE_CAST(obj)            ((GstVimbaSrcDevice *)(obj))
+
+struct _GstVimbaSrcDevice {
+  GstDevice   parent;
+
+  gchar       *camera_id;
+  gchar       *camera_model;
+  gchar       *camera_name;
+  gchar       *interface_id;
+  gchar       *serial;
+  const gchar *element;
+};
+
+struct _GstVimbaSrcDeviceClass {
+  GstDeviceClass    parent_class;
+};
+
+GType gst_vimbasrc_device_get_type(void);
+
+G_END_DECLS
+
+#endif // _GST_VIMBASRC_DEVICE_H_

--- a/src/gstvimbasrc_deviceprovider.c
+++ b/src/gstvimbasrc_deviceprovider.c
@@ -183,7 +183,7 @@ gst_vimbasrc_device_provider_probe (GstDeviceProvider *provider)
 
       for (VmbUint32_t i = 0; i < count; ++i)
       {
-        self->devices = g_list_append(self->devices, create_gstdevice_from_vmbcamerainfo(cameras + i));
+        gst_device_provider_device_add(provider, create_gstdevice_from_vmbcamerainfo(cameras + i));
       }
     }
     else
@@ -216,15 +216,15 @@ gst_vimbasrc_device_provider_start(GstDeviceProvider *provider)
 
   GST_DEBUG_OBJECT(self, "Starting vimba device provider");
 
-  /* TODO: The base class does not call _probe so only added devices will be shown in gst-device-monitor-1.0
-           Should we call _probe our own?
-  */
-
   VmbError_t err = VmbFeatureInvalidationRegister(gVimbaHandle, "DiscoveryCameraEvent", callback_vimba_camera_discovery, self);
   if (err != VmbErrorSuccess) {
     GST_ERROR_OBJECT(self, "Starting vimba device provider failed.");
     return FALSE;
   }
+
+  /* The base class does not call _probe so only added devices will be shown in gst-device-monitor-1.0, this is workaround. */
+  gst_vimbasrc_device_provider_probe(provider);
+
   return TRUE;
 }
 

--- a/src/gstvimbasrc_deviceprovider.c
+++ b/src/gstvimbasrc_deviceprovider.c
@@ -1,0 +1,310 @@
+/*
+ * Copyright (C) 2023 Allied Vision Technologies GmbH
+ * Copyright (C) 2023 Fraunhofer Institute for Material and Beam Technology IWS
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License version 2.0 as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "gstvimbasrc_deviceprovider.h"
+#include "gstvimbasrc_device.h"
+#include "gstvimbasrc.h"
+
+#include <gst/gst.h>
+#include <gst/video/video-format.h>
+#include <VimbaC/Include/VimbaC.h>
+
+#ifdef WIN32
+    #define UNUSED_ATTR(x) x
+#else
+    #define UNUSED_ATTR(x) x __attribute__((unused))
+#endif
+
+G_DEFINE_TYPE(GstVimbaSrcDeviceProvider, gst_vimbasrc_device_provider, GST_TYPE_DEVICE_PROVIDER)
+
+/**
+ * @brief Create a GstDevice from Vimba camera info object
+ *
+ * @param camera A camera information pointer from Vimba API (caller owns)
+ * @return GstDevice* Created GstDevice (transfer ownership to caller)
+ */
+GstDevice *
+create_gstdevice_from_vmbcamerainfo(VmbCameraInfo_t* camera)
+{
+  gchar *display_name = g_strdup_printf("%s (id=%s)", camera->cameraName, camera->cameraIdString);
+  GstCaps *caps = gst_caps_from_string(GST_VIDEO_CAPS_MAKE(GST_VIDEO_FORMATS_ALL));
+  gst_caps_append(caps, gst_caps_from_string(GST_BAYER_CAPS_MAKE(GST_BAYER_FORMATS_ALL)));
+
+  GstVimbaSrcDevice *device = g_object_new(GST_TYPE_VIMBASRC_DEVICE,
+                                           "display-name", display_name,
+                                           "device-class", "Video/Source",
+                                           "caps", caps,
+                                           "camera-id", camera->cameraIdString,
+                                           "camera-model", camera->modelName,
+                                           "camera-name", camera->cameraName,
+                                           "interface-id", camera->interfaceIdString,
+                                           "serial", camera->serialString,
+                                           NULL);
+  g_free(display_name);
+  gst_caps_unref(caps);
+
+  return GST_DEVICE(device);
+}
+
+/**
+ * @brief Callback for Vimba API on camera discovery events
+ *
+ * @param handle Vimba handle the event was emitted for
+ * @param name Event name
+ * @param context User context (GstDeviceProvider*)
+ */
+void VMB_CALL
+callback_vimba_camera_discovery(VmbHandle_t handle, const char* name, void* context)
+{
+  GST_TRACE("Vimba callback: %s", name);
+  VmbError_t err = VmbErrorSuccess;
+  GstDeviceProvider *self = GST_DEVICE_PROVIDER(context);
+
+  char camera_id[255];
+  const char* callback_reason = NULL;
+
+  VmbFeatureEnumGet(handle, "DiscoveryCameraEvent", &callback_reason);
+  VmbFeatureStringGet(handle, "DiscoveryCameraIdent", camera_id, 255, NULL);
+
+  if (strcmp(callback_reason, "Detected") == 0)
+  {
+    VmbCameraInfo_t camera;
+    err = VmbCameraInfoQuery(camera_id, &camera, sizeof camera);
+    if (err != VmbErrorSuccess)
+    {
+      GST_ERROR_OBJECT(self, "Could not retrieve camera information.");
+      return;
+    }
+
+    GST_DEBUG_OBJECT(self, "Adding new %s device (id: %s)", camera.cameraName, camera.cameraIdString);
+
+    GstDevice *device = create_gstdevice_from_vmbcamerainfo(&camera);
+    gst_device_provider_device_add(self, device);
+  }
+  else if (strcmp(callback_reason, "Missing") == 0)
+  {
+    for (GList *item = self->devices; item; item = item->next)
+    {
+      GstVimbaSrcDevice *device = GST_VIMBASRC_DEVICE(item->data);
+      if (strcmp(device->camera_id, camera_id) == 0)
+      {
+        gst_device_provider_device_remove(self, GST_DEVICE(device));
+        break;
+      }
+    }
+  }
+  else
+  {
+    GST_DEBUG_OBJECT(self, "Unhandled option %s", callback_reason);
+    // currently noop (Reachable, Unreachable)
+  }
+}
+
+static void
+gst_vimbasrc_device_provider_set_property (GObject *object, guint property_id, const GValue * UNUSED_ATTR(value), GParamSpec *pspec)
+{
+  switch (property_id) {
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+      break;
+  }
+}
+
+static void
+gst_vimbasrc_device_provider_get_property (GObject *object, guint property_id, GValue * UNUSED_ATTR(value), GParamSpec *pspec)
+{
+  switch (property_id) {
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+      break;
+  }
+}
+
+/**
+ * @brief GStreamer function called to query all connected devices
+ *
+ * Use the Vimba API to query all connected cameras
+ *
+ * @param provider GstVimbaSrcDeviceProvider
+ * @return GList*
+ */
+static GList *
+gst_vimbasrc_device_provider_probe (GstDeviceProvider *provider)
+{
+  GstVimbaSrcDeviceProvider *self = GST_VIMBASRC_DEVICE_PROVIDER(provider);
+
+  VmbError_t      err      = VmbErrorSuccess;
+  VmbCameraInfo_t *cameras = NULL;
+  VmbUint32_t     count    = 0;
+  VmbUint32_t     found    = 0;
+
+  // We can not probe for GigE cameras, because that would be blocking (not allowed in _probe)
+  GST_DEBUG_OBJECT(self, "Starting probe vimba");
+
+  self->devices = NULL;
+
+  // number of known cameras
+  err = VmbCamerasList( NULL, 0, &count, sizeof *cameras);
+  if (VmbErrorSuccess == err && count != 0)
+  {
+    GST_TRACE_OBJECT(self, "Cameras found: %d", count);
+
+    cameras = (VmbCameraInfo_t*)malloc(sizeof *cameras * count);
+    if (cameras == NULL)
+    {
+      GST_ERROR_OBJECT(self, "Could not allocate camera list.");
+      return NULL;
+    }
+
+    // Query all static details of all known cameras
+    err = VmbCamerasList(cameras, count, &found, sizeof *cameras);
+    if(VmbErrorSuccess == err ||  VmbErrorMoreData == err)
+    {
+      if(found < count)
+      {
+        count = found;
+      }
+
+      for (VmbUint32_t i = 0; i < count; ++i)
+      {
+        self->devices = g_list_append(self->devices, create_gstdevice_from_vmbcamerainfo(cameras + i));
+      }
+    }
+    else
+    {
+      GST_ERROR_OBJECT(self, "Could not retrieve camera list.");
+    }
+    free(cameras);
+  }
+  else if (VmbErrorSuccess != err)
+  {
+    GST_ERROR_OBJECT(self, "Could not list cameras.");
+    return NULL;
+  }
+
+  return self->devices;
+}
+
+/**
+ * @brief GStreamer function used to start listening for changed devices
+ *
+ * Registers the Vimba camera discovery event handler
+ *
+ * @param provider GstVimbaSrcDeviceProvider
+ * @return True if the event handler could be registered
+ */
+static gboolean
+gst_vimbasrc_device_provider_start(GstDeviceProvider *provider)
+{
+  GstVimbaSrcDeviceProvider *self = GST_VIMBASRC_DEVICE_PROVIDER(provider);
+
+  GST_DEBUG_OBJECT(self, "Starting vimba device provider");
+
+  /* TODO: The base class does not call _probe so only added devices will be shown in gst-device-monitor-1.0
+           Should we call _probe our own?
+  */
+
+  VmbError_t err = VmbFeatureInvalidationRegister(gVimbaHandle, "DiscoveryCameraEvent", callback_vimba_camera_discovery, self);
+  if (err != VmbErrorSuccess) {
+    GST_ERROR_OBJECT(self, "Starting vimba device provider failed.");
+    return FALSE;
+  }
+  return TRUE;
+}
+
+/**
+ * @brief GStreamer function used to stop listening for changed devices
+ *
+ * Unregisters the Vimba camera discovery event handler
+ *
+ * @param provider GstVimbaSrcDeviceProvider
+ */
+static void
+gst_vimbasrc_device_provider_stop(GstDeviceProvider *provider)
+{
+  GstVimbaSrcDeviceProvider *self = GST_VIMBASRC_DEVICE_PROVIDER(provider);
+
+  GST_DEBUG_OBJECT (self, "stopping provider");
+
+  VmbError_t err = VmbFeatureInvalidationUnregister(gVimbaHandle, "DiscoveryCameraEvent", callback_vimba_camera_discovery);
+  if (err != VmbErrorSuccess) {
+    GST_WARNING_OBJECT(self, "Stopping vimba device provider failed.");
+  }
+}
+
+/**
+ * @brief GLib function to free a GstVimbaSrcDeviceProvider
+ *
+ * Used to release the Vimba API if needed
+ *
+ * @param object The GstVimbaSrcDeviceProvider to free
+ */
+static void
+gst_vimbasrc_device_provider_finalize(GObject *object)
+{
+  GstVimbaSrcDeviceProvider *self = GST_VIMBASRC_DEVICE_PROVIDER(object);
+
+  stop_vimba(GST_OBJECT(self));
+
+  G_OBJECT_CLASS(gst_vimbasrc_device_provider_parent_class)->finalize(object);
+}
+
+/**
+ * @brief GLib function to initialize the GstVimbaSrcDeviceProvider class struct
+ *
+ * Used to register out start / stop / probe functions.
+ *
+ * @param klass
+ */
+static void
+gst_vimbasrc_device_provider_class_init(GstVimbaSrcDeviceProviderClass *klass)
+{
+  GObjectClass *gobject_class = G_OBJECT_CLASS(klass);
+  GstDeviceProviderClass *dp_class = GST_DEVICE_PROVIDER_CLASS(klass);
+
+  gobject_class->set_property = gst_vimbasrc_device_provider_set_property;
+  gobject_class->get_property = gst_vimbasrc_device_provider_get_property;
+  gobject_class->finalize = gst_vimbasrc_device_provider_finalize;
+
+  dp_class->probe = gst_vimbasrc_device_provider_probe;
+  dp_class->start = gst_vimbasrc_device_provider_start;
+  dp_class->stop = gst_vimbasrc_device_provider_stop;
+
+  gst_device_provider_class_set_static_metadata (
+    dp_class,
+    "VimbaSrc Device Provider",
+    "Source/Video",
+    "List and provide Vimba camera devices",
+    "Allied Vision Technologies GmbH"
+  );
+}
+
+/**
+ * @brief GLib function to initialize a GstVimbaSrcDeviceProvider instance
+ *
+ * Used to start the Vimba API if needed
+ *
+ * @param self The GstVimbaSrcDeviceProvider to initialize
+ */
+static void
+gst_vimbasrc_device_provider_init(GstVimbaSrcDeviceProvider *self)
+{
+  GST_TRACE_OBJECT(self, "gst-vimbasrc-device-provider init");
+  start_vimba(GST_OBJECT(self));
+}

--- a/src/gstvimbasrc_deviceprovider.h
+++ b/src/gstvimbasrc_deviceprovider.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023 Allied Vision Technologies GmbH
+ * Copyright (C) 2023 Fraunhofer Institute for Material and Beam Technology IWS
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License version 2.0 as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef _GST_vimbaprovider_H_
+#define _GST_vimbaprovider_H_
+
+#include <glib.h>
+#include <gst/base/base.h>
+
+G_BEGIN_DECLS
+
+/* The GstDeviceProvider */
+
+typedef struct _GstVimbaSrcDeviceProvider GstVimbaSrcDeviceProvider;
+typedef struct _GstVimbaSrcDeviceProviderClass GstVimbaSrcDeviceProviderClass;
+
+#define GST_TYPE_VIMBASRC_DEVICE_PROVIDER             (gst_vimbasrc_device_provider_get_type())
+#define GST_IS_VIMBASRC_DEVICE_PROVIDER(obj)          (G_TYPE_CHECK_INSTANCE_TYPE ((obj), GST_TYPE_VIMBASRC_DEVICE_PROVIDER))
+#define GST_IS_VIMBASRC_DEVICE_PROVIDER_CLASS(klass)  (G_TYPE_CHECK_CLASS_TYPE ((klass), GST_TYPE_VIMBASRC_DEVICE_PROVIDER))
+#define GST_VIMBASRC_DEVICE_PROVIDER_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS ((obj), GST_TYPE_VIMBASRC_DEVICE_PROVIDER, GstVimbaSrcDeviceProviderClass))
+#define GST_VIMBASRC_DEVICE_PROVIDER(obj)             (G_TYPE_CHECK_INSTANCE_CAST ((obj), GST_TYPE_VIMBASRC_DEVICE_PROVIDER, GstVimbaSrcDeviceProvider))
+#define GST_VIMBASRC_DEVICE_PROVIDER_CLASS(klass)     (G_TYPE_CHECK_CLASS_CAST ((klass), GST_TYPE_DEVICE_PROVIDER, GstVimbaSrcDeviceProviderClass))
+#define GST_VIMBASRC_DEVICE_PROVIDER_CAST(obj)        ((GstVimbaSrcDeviceProvider *)(obj))
+
+struct _GstVimbaSrcDeviceProvider {
+  GstDeviceProvider         parent;
+  GstDeviceProviderFactory* factory;
+
+  GList *devices;
+};
+
+struct _GstVimbaSrcDeviceProviderClass {
+  GstDeviceProviderClass    parent_class;
+};
+
+GType gst_vimbasrc_device_provider_get_type(void);
+
+G_END_DECLS
+
+#endif


### PR DESCRIPTION
This allows to use `gst-device-monitor-1.0` to listen for new connected devices or to use GstDeviceMonitor API for this purpose.
Currently GigE cameras are not handled, as we only use USB cameras so without a camera device to test I would feel bad to write untested code for that devices.

Tested with Alvium cameras.